### PR TITLE
fix: add missing comma after QrCode import

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -7,7 +7,7 @@ import {
   Smartphone,
   Settings,
   Zap,
-  QrCode
+  QrCode,
   Sparkles,
   ScanLine,
   Server


### PR DESCRIPTION
Same fix as Wallesters-org/Wallestars PR #158. Fixes build error.