### PR TITLE
security: remove hardcoded secrets, sync .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ ANTHROPIC_API_KEY=your_api_key_here
 # Server Configuration
 PORT=3000
 NODE_ENV=development
+FRONTEND_URL=http://localhost:5173
+ALLOWED_ORIGIN=http://localhost:5173
+
+# Authentication
+WALLESTARS_API_KEY=ws-your_wallestars_api_key_here
 
 # Linux Computer Use
 ENABLE_COMPUTER_USE=true
@@ -20,6 +25,8 @@ WS_PORT=3001
 # Hostinger API Configuration
 HOSTINGER_API_TOKEN=your_hostinger_api_token_here
 HOSTINGER_API_BASE_URL=https://api.hostinger.com
+HOSTINGER_API_TIMEOUT=30000
+
 # N8N Integration
 N8N_WEBHOOK_URL=https://your-n8n-server.domain.com
 N8N_API_KEY=your_n8n_api_key_here
@@ -52,47 +59,59 @@ HOSTINGER_IMAP_CREDENTIAL_ID=your_n8n_hostinger_credential_id
 # Airtop - AI Browser Automation
 AIRTOP_API_KEY=your_airtop_api_key_here
 AIRTOP_API_BASE_URL=https://api.airtop.ai/v1
+AIRTOP_API_TIMEOUT=60000
 
 # GitLab - Code Repository Management
 GITLAB_API_TOKEN=your_gitlab_api_token_here
 GITLAB_API_BASE_URL=https://gitlab.com/api/v4
+GITLAB_API_TIMEOUT=30000
 
 # Slack - Team Communication
 SLACK_BOT_TOKEN=xoxb-your-slack-bot-token
 SLACK_SIGNING_SECRET=your_slack_signing_secret
+SLACK_API_TIMEOUT=30000
 
 # Discord - Community Management
 DISCORD_BOT_TOKEN=your_discord_bot_token_here
+DISCORD_API_TIMEOUT=30000
 
 # OpenAI - GPT Models & AI Services
 OPENAI_API_KEY=sk-your_openai_api_key_here
 OPENAI_API_BASE_URL=https://api.openai.com/v1
+OPENAI_API_TIMEOUT=120000
 
 # Notion - Documentation & Knowledge Base
 NOTION_API_KEY=secret_your_notion_api_key_here
+NOTION_API_TIMEOUT=30000
 
 # Twilio - SMS & Voice
 TWILIO_ACCOUNT_SID=your_twilio_account_sid
 TWILIO_AUTH_TOKEN=your_twilio_auth_token
 TWILIO_PHONE_NUMBER=+1234567890
 TWILIO_VERIFY_SERVICE_SID=your_verify_service_sid
+TWILIO_API_TIMEOUT=30000
 
 # SendGrid - Email Services
 SENDGRID_API_KEY=SG.your_sendgrid_api_key
 SENDGRID_FROM_EMAIL=noreply@yourdomain.com
 SENDGRID_FROM_NAME=Your App Name
+SENDGRID_API_TIMEOUT=30000
 
 # Jira - Project Management
 JIRA_BASE_URL=https://your-domain.atlassian.net
 JIRA_EMAIL=your_email@example.com
 JIRA_API_TOKEN=your_jira_api_token_here
+JIRA_API_TIMEOUT=30000
 
 # Linear - Issue Tracking
 LINEAR_API_KEY=lin_api_your_linear_api_key
+LINEAR_API_TIMEOUT=30000
 
 # Vercel - Deployment Platform
 VERCEL_API_TOKEN=your_vercel_api_token_here
 VERCEL_TEAM_ID=your_vercel_team_id
+VERCEL_API_TIMEOUT=60000
 
 # Replicate - AI Model Hosting
 REPLICATE_API_TOKEN=r8_your_replicate_api_token
+REPLICATE_API_TIMEOUT=120000

--- a/server/utils/otpWatchdog.js
+++ b/server/utils/otpWatchdog.js
@@ -1,14 +1,18 @@
 // OTP Watchdog - alerts when registrations stuck in otp_pending > 15 minutes
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = process.env.SUPABASE_URL || 'https://ansiaiuaygcfztabtknl.supabase.co';
+const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const STUCK_THRESHOLD_MINUTES = 15;
 
-const supabase = SUPABASE_KEY ? createClient(SUPABASE_URL, SUPABASE_KEY) : null;
+if (!SUPABASE_URL && SUPABASE_KEY) {
+  console.warn('⚠️ SUPABASE_URL is not set — OTP watchdog disabled');
+}
+
+const supabase = (SUPABASE_URL && SUPABASE_KEY) ? createClient(SUPABASE_URL, SUPABASE_KEY) : null;
 
 export async function checkStuckOtpRegistrations() {
   if (!supabase) return;

--- a/server/utils/otpWatchdog.test.js
+++ b/server/utils/otpWatchdog.test.js
@@ -17,6 +17,7 @@ vi.mock('@supabase/supabase-js', () => ({
 
 // Provide required env vars
 beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://test-project.supabase.co';
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
   process.env.TELEGRAM_BOT_TOKEN = '';
   process.env.TELEGRAM_CHAT_ID = '-100000000000';
@@ -24,6 +25,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_SERVICE_ROLE_KEY;
 });
 


### PR DESCRIPTION
## Summary

- **Removes hardcoded Supabase project URL** (`https://ansiaiuaygcfztabtknl.supabase.co`) from `server/utils/otpWatchdog.js` — now requires `SUPABASE_URL` env var
- **Guards OTP watchdog** on both `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` being set; warns if key is set but URL is missing
- **Syncs `.env.example`** with all 51 `process.env.*` variables used across the server codebase — adds 16 previously missing vars:
  - `FRONTEND_URL`, `ALLOWED_ORIGIN`, `WALLESTARS_API_KEY`
  - 13 API timeout vars: `HOSTINGER_API_TIMEOUT`, `AIRTOP_API_TIMEOUT`, `GITLAB_API_TIMEOUT`, `SLACK_API_TIMEOUT`, `DISCORD_API_TIMEOUT`, `OPENAI_API_TIMEOUT`, `NOTION_API_TIMEOUT`, `TWILIO_API_TIMEOUT`, `SENDGRID_API_TIMEOUT`, `JIRA_API_TIMEOUT`, `LINEAR_API_TIMEOUT`, `VERCEL_API_TIMEOUT`, `REPLICATE_API_TIMEOUT`
- **Updates `otpWatchdog.test.js`** to set `SUPABASE_URL` in test environment

## Audit Results

Full server audit found **no other hardcoded secrets** — all API URLs in service clients (`vercelClient.js`, `twilioClient.js`, etc.) are well-known public API base URLs, not project-specific credentials.

## Test Plan

- [x] All 184 existing tests pass (`npx vitest run`)
- [ ] Deploy to staging and verify OTP watchdog still starts with `SUPABASE_URL` set
- [ ] Verify watchdog gracefully disables when `SUPABASE_URL` is unset

---
🤖 *Generated by Computer*