### PR TITLE
fix: MCP CI — add SUPABASE_URL env to test workflow

### DIFF
--- a/.github/workflows/mcp-enhanced-automation.yml
+++ b/.github/workflows/mcp-enhanced-automation.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Test MCP server startup
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           # Start server in background
           node server/index.js &
@@ -88,6 +91,9 @@ jobs:
       - name: Test MCP endpoints
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           # Start server
           node server/index.js &

--- a/server/routes/contractSigning.js
+++ b/server/routes/contractSigning.js
@@ -1,18 +1,22 @@
 import express from 'express';
 import { createClient } from '@supabase/supabase-js';
 
-// Startup guard: require Supabase env vars
-if (!process.env.SUPABASE_URL) {
-  throw new Error('SUPABASE_URL environment variable is required');
+let _supabase;
+function getSupabase() {
+  if (!_supabase) {
+    if (!process.env.SUPABASE_URL) {
+      throw new Error('SUPABASE_URL environment variable is required');
+    }
+    if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+      throw new Error('SUPABASE_SERVICE_ROLE_KEY environment variable is required');
+    }
+    _supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+  }
+  return _supabase;
 }
-if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-  throw new Error('SUPABASE_SERVICE_ROLE_KEY environment variable is required');
-}
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-);
 
 const router = express.Router();
 
@@ -42,6 +46,7 @@ router.post('/:id/sign-contract', async (req, res) => {
   try {
     // Verify the registration belongs to the requesting user
     // First fetch the record to check ownership
+    const supabase = getSupabase();
     const { data: existing, error: fetchError } = await supabase
       .from('registration_progress')
       .select('id, user_id, current_step')


### PR DESCRIPTION
## Summary
- Made Supabase client initialization **lazy** in `server/routes/contractSigning.js` — env vars are checked when the route is first called, not on module import. This lets the server start in CI without Supabase credentials.
- Added `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` from GitHub secrets to both server-startup steps in `.github/workflows/mcp-enhanced-automation.yml`.

## Root Cause
`contractSigning.js` was imported at the top of `server/index.js` (line 36), **before** `dotenv.config()` runs (line 38). The module-level `throw` on missing `SUPABASE_URL` crashed the server immediately on import, failing the "Test MCP server startup" step.

## What Changed
| File | Change |
|------|--------|
| `server/routes/contractSigning.js` | Replaced eager `throw` + top-level `createClient()` with a lazy `getSupabase()` helper that initializes on first route call |
| `.github/workflows/mcp-enhanced-automation.yml` | Added Supabase env vars to `Test MCP server startup` and `Test MCP endpoints` steps |

## Test plan
- [ ] MCP Enhanced Automation workflow passes (server startup + endpoint tests)
- [ ] Contract signing route still works when `SUPABASE_URL` is set (lazy init is transparent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)