### PR TITLE
ci: make n8n webhook notifications non-blocking

### DIFF
--- a/.github/workflows/master-automation-orchestrator.yml
+++ b/.github/workflows/master-automation-orchestrator.yml
@@ -281,10 +281,14 @@ jobs:
               .addRaw(successRate > 90 ? '✅ Excellent\n' : successRate > 75 ? '🟡 Good\n' : '🔴 Needs Improvement\n')
               .write();
 
-      - name: Send webhook notification
-        if: env.N8N_WEBHOOK_URL != ''
+      - name: Send webhook notification (non-blocking)
+        if: ${{ env.N8N_WEBHOOK_URL != '' }}
+        continue-on-error: true
         run: |
-          curl -X POST "${{ env.N8N_WEBHOOK_URL }}/webhook/automation-summary" \
+          set +e
+          HTTP=$(curl -sS -o /tmp/n8n_resp.txt -w '%{http_code}' \
+            --max-time 25 --connect-timeout 10 --retry 1 --retry-delay 5 \
+            -X POST "${{ env.N8N_WEBHOOK_URL }}/webhook/automation-summary" \
             -H "Content-Type: application/json" \
             -d '{
               "workflow": "master-orchestrator",
@@ -292,7 +296,14 @@ jobs:
               "timestamp": "'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'",
               "target": "${{ github.event.inputs.target || 'scheduled' }}",
               "repository": "${{ github.repository }}"
-            }'
+            }')
+          EXIT=$?
+          if [ $EXIT -ne 0 ] || [ "${HTTP:0:1}" != "2" ]; then
+            echo "::warning title=n8n webhook unavailable::POST /webhook/automation-summary → exit=$EXIT http=$HTTP (non-blocking)"
+          else
+            echo "::notice::n8n webhook OK ($HTTP)"
+          fi
+          exit 0
 
   cleanup-old-runs:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-automation.yml
+++ b/.github/workflows/testing-automation.yml
@@ -197,9 +197,14 @@ jobs:
       N8N_WEBHOOK_URL: ${{ secrets.N8N_WEBHOOK_URL }}
     
     steps:
-      - name: Изпрати резултати към n8n
+      - name: Изпрати резултати към n8n (non-blocking)
+        if: ${{ env.N8N_WEBHOOK_URL != '' }}
+        continue-on-error: true
         run: |
-          curl -X POST "${N8N_WEBHOOK_URL}/webhook/test-results" \
+          set +e
+          HTTP=$(curl -sS -o /tmp/n8n_resp.txt -w '%{http_code}' \
+            --max-time 25 --connect-timeout 10 --retry 1 --retry-delay 5 \
+            -X POST "${N8N_WEBHOOK_URL}/webhook/test-results" \
             -H "Content-Type: application/json" \
             -d '{
               "workflow": "testing-automation",
@@ -210,4 +215,11 @@ jobs:
               "timestamp": "'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'",
               "repository": "${{ github.repository }}",
               "pr_number": "${{ github.event.pull_request.number || 'N/A' }}"
-            }'
+            }')
+          EXIT=$?
+          if [ $EXIT -ne 0 ] || [ "${HTTP:0:1}" != "2" ]; then
+            echo "::warning title=n8n webhook unavailable::POST /webhook/test-results → exit=$EXIT http=$HTTP (non-blocking)"
+          else
+            echo "::notice::n8n webhook OK ($HTTP)"
+          fi
+          exit 0


### PR DESCRIPTION
## Summary

When the self-hosted n8n instance at `n8n.srv1201204.hstgr.cloud` is unreachable, the trailing webhook step has been failing entire workflow runs even though all tests, code-quality checks, security scans, and build verifications had already passed. This PR decouples CI health from n8n uptime.

## Evidence of the problem

Run [24617663288](https://github.com/kirkomrk2-web/Wallestars/actions/runs/24617663288) — `Automated Testing & Deployment`:
- `run-tests` (Node 20, 22) — ✅
- `code-quality` — ✅
- `security-scan` — ✅
- `build-verification` — ✅
- `notify-results` (`Изпрати резултати към n8n`) — ❌ `curl: (28) Failed to connect to n8n.srv1201204.hstgr.cloud port 443 after 136322 ms`

Same pattern in run [24617661572](https://github.com/kirkomrk2-web/Wallestars/actions/runs/24617661572) for `Master Automation Orchestrator`'s `Send webhook notification` step. Direct probe from outside Hostinger confirms TCP/443 on that host currently times out.

## Changes

`.github/workflows/testing-automation.yml` — `notify-results` job:
- Add `--max-time 25`, `--connect-timeout 10`, one retry with 5s backoff.
- Wrap step in `continue-on-error: true`.
- Guard with `if: env.N8N_WEBHOOK_URL != ''` so a missing secret doesn't produce a noisy failure.
- On timeout/4xx/5xx, emit a `::warning` so the signal is still visible in the run summary.

`.github/workflows/master-automation-orchestrator.yml` — `Send webhook notification` step: same treatment.

## Why this is safe

- Only touches two notification steps; no code, tests, or build logic changes.
- `continue-on-error: true` is scoped to these two steps, not the jobs or workflows.
- Warnings are preserved so n8n outages remain visible in the UI.
- Fully reversible: revert this commit restores the prior behaviour.

## Related
Pairs well with `ci/health-score-loop-fix` (keeps the orchestrator's own failures from inflating the score) and eventually with restoring n8n at `srv1201204`.
