### PR TITLE
security: bump actions/download-artifact to v4.1.9 (CVE-2024-42471)

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v4.1.9
         with:
           name: node-app
 

--- a/.github/workflows/deploy-hostinger-vps.yml
+++ b/.github/workflows/deploy-hostinger-vps.yml
@@ -82,7 +82,7 @@ jobs:
     
     steps:
     - name: Download deployment artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.9
       with:
         name: deployment-package
     


### PR DESCRIPTION
## Summary

Closes #24. CVE-2024-42471 affects `actions/download-artifact` versions prior to v4.1.7. Two workflows in this repo pinned pre-fix versions:

| File | Before | After |
|---|---|---|
| `.github/workflows/azure-webapps-node.yml:74` | `actions/download-artifact@v4.1.3` | `actions/download-artifact@v4.1.9` |
| `.github/workflows/deploy-hostinger-vps.yml:85` | `actions/download-artifact@v4` (floating; could resolve ≤ v4.1.6) | `actions/download-artifact@v4.1.9` |

`v4.1.9` is the latest v4 maintenance release and contains the fix for CVE-2024-42471. No API changes across v4.1.3 → v4.1.9 affect our usage; no workflow inputs need to change.

## Why this is safe

- Pinning to an exact minor reduces ambiguity versus the floating `@v4` tag.
- No behaviour change for our artifact download steps.
- Fully reversible.

## Verification

- Action docs: https://github.com/actions/download-artifact/releases
- Advisory: https://github.com/advisories/GHSA-... (CVE-2024-42471)

Closes #24.
