### PR TITLE
refactor(ui): share motion presets and reuse layoutId tab indicator

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { NavLink } from 'react-router-dom';
+import { tabSpring } from '../utils/motion';
 import {
   LayoutDashboard,
   MessageSquare,
@@ -89,7 +90,7 @@ export default function Sidebar({ isOpen }) {
                       <motion.div
                         layoutId="activeTab"
                         className="absolute inset-0 bg-gradient-to-r from-primary-500 to-primary-600"
-                        transition={{ type: 'spring', bounce: 0.2, duration: 0.6 }}
+                        transition={tabSpring}
                       />
                     )}
 

--- a/src/pages/HostingerManagement.jsx
+++ b/src/pages/HostingerManagement.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
+import { tabSpring } from '../utils/motion';
 import { 
   Server, 
   CreditCard, 
@@ -283,19 +284,31 @@ export default function HostingerManagement() {
 
         {/* Tabs */}
         <div className="flex gap-2 mb-6 overflow-x-auto">
-          {['overview', 'vps', 'subscriptions', 'billing'].map((tab) => (
-            <button
-              key={tab}
-              onClick={() => setActiveTab(tab)}
-              className={`px-4 py-2 rounded-lg transition-all ${
-                activeTab === tab
-                  ? 'bg-sky-500 text-white'
-                  : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
-              }`}
-            >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
-            </button>
-          ))}
+          {['overview', 'vps', 'subscriptions', 'billing'].map((tab) => {
+            const isActive = activeTab === tab;
+            return (
+              <button
+                key={tab}
+                onClick={() => setActiveTab(tab)}
+                className={`relative px-4 py-2 rounded-lg transition-colors ${
+                  isActive
+                    ? 'text-white'
+                    : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                }`}
+              >
+                {isActive && (
+                  <motion.div
+                    layoutId="hostingerActiveTab"
+                    className="absolute inset-0 bg-sky-500 rounded-lg"
+                    transition={tabSpring}
+                  />
+                )}
+                <span className="relative z-10">
+                  {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                </span>
+              </button>
+            );
+          })}
         </div>
 
         {/* Content */}

--- a/src/pages/MultiAgentDesign.jsx
+++ b/src/pages/MultiAgentDesign.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { tabSpring, buttonTap } from '../utils/motion';
 import {
   Brain,
   Network,
@@ -312,20 +313,27 @@ export default function MultiAgentDesign() {
       <div className="flex flex-wrap gap-2">
         {tabs.map((tab) => {
           const Icon = tab.icon;
+          const isActive = activeTab === tab.id;
           return (
             <motion.button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
-              className={`flex items-center gap-2 px-4 py-2.5 rounded-xl font-medium text-sm transition-all duration-200 ${
-                activeTab === tab.id
-                  ? 'bg-gradient-to-r from-indigo-500 to-purple-600 text-white shadow-lg shadow-indigo-500/30'
-                  : 'glass-effect-hover text-dark-300 hover:text-white'
+              {...buttonTap}
+              className={`relative flex items-center gap-2 px-4 py-2.5 rounded-xl font-medium text-sm overflow-hidden ${
+                isActive
+                  ? 'text-white shadow-lg shadow-indigo-500/30'
+                  : 'glass-effect-hover text-dark-300 hover:text-white transition-colors duration-200'
               }`}
             >
-              <Icon className="w-4 h-4" />
-              {tab.label}
+              {isActive && (
+                <motion.div
+                  layoutId="multiAgentActiveTab"
+                  className="absolute inset-0 bg-gradient-to-r from-indigo-500 to-purple-600"
+                  transition={tabSpring}
+                />
+              )}
+              <Icon className="w-4 h-4 relative z-10" />
+              <span className="relative z-10">{tab.label}</span>
             </motion.button>
           );
         })}

--- a/src/utils/motion.js
+++ b/src/utils/motion.js
@@ -1,0 +1,28 @@
+// Shared Framer Motion presets for common animation patterns used across the
+// app. Keep this module small and focused on patterns that already repeat in
+// several places.
+
+export const fadeIn = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+};
+
+export const fadeInUp = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+};
+
+export const fadeInDown = {
+  initial: { opacity: 0, y: -20 },
+  animate: { opacity: 1, y: 0 },
+};
+
+// Spring used for the active-tab pill indicator (matches Sidebar's existing
+// transition so all tab selectors feel the same).
+export const tabSpring = { type: 'spring', bounce: 0.2, duration: 0.6 };
+
+// Standard interactive button feedback used throughout the app.
+export const buttonTap = {
+  whileHover: { scale: 1.02 },
+  whileTap: { scale: 0.98 },
+};


### PR DESCRIPTION
## Summary

Low-risk UI polish follow-up to PR #37, scoped to two changes:

1. **New `src/utils/motion.js`** — a small module exporting the Framer Motion presets that already repeat across the app: `fadeIn`, `fadeInUp`, `fadeInDown`, `tabSpring` (the active-pill spring used by the sidebar), and `buttonTap` (the `whileHover: 1.02 / whileTap: 0.98` pair used on most action buttons). Kept intentionally tiny — only patterns that are already duplicated.
2. **Reuse the `layoutId` active-pill pattern** from `src/components/Sidebar.jsx` on the two existing tab selectors that obviously benefit:
   - `src/pages/HostingerManagement.jsx` (`overview / vps / subscriptions / billing`) — `layoutId="hostingerActiveTab"`.
   - `src/pages/MultiAgentDesign.jsx` (`tabs.map(...)`) — `layoutId="multiAgentActiveTab"`.
   Each uses its own unique `layoutId` so the indicators don't cross-animate. `Sidebar.jsx` is unchanged behaviorally — it just imports `tabSpring` from the new util instead of inlining `{ type: 'spring', bounce: 0.2, duration: 0.6 }`.

Out of scope (intentionally not included): `whileInView`/`staggerChildren` card-grid refactors, shimmer/skeleton replacements, broader route transition changes, dependency upgrades, styling redesigns.

## Files changed

- `src/utils/motion.js` (new)
- `src/components/Sidebar.jsx` (use shared `tabSpring`)
- `src/pages/HostingerManagement.jsx` (animated pill via `layoutId`)
- `src/pages/MultiAgentDesign.jsx` (animated pill via `layoutId`, `buttonTap` preset)

## Test plan

- [x] `npm install --legacy-peer-deps`
- [x] `npm run test` — 184/184 passed
- [x] `npm run build` — succeeds, no type/JSX errors
- [ ] Manual: switch tabs in Hostinger VPS and Multi-Agent Design pages — pill should glide, not snap.
- [ ] Manual: sidebar nav still animates exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)